### PR TITLE
example of using a custom log stream

### DIFF
--- a/examples/ZeroRegsExampleLogger/ExampleLogPrint.h
+++ b/examples/ZeroRegsExampleLogger/ExampleLogPrint.h
@@ -1,11 +1,11 @@
 #ifndef EXAMPLE_LOG_STREAM_H
 #define EXAMPLE_LOG_STREAM_H
 
-#include <Stream.h>
+#include <Print.h>
 
 
-class ExampleLogStream : public Stream {
-    Stream &wrapped;
+class ExampleLogPrint : public Print {
+    Print &wrapped;
     bool prefixWritten;
 
     // copied(simplified) from platformio packages/framework-arduinosam/cores/samd/Print.cpp
@@ -35,20 +35,9 @@ class ExampleLogStream : public Stream {
     }
 
 public:
-    ExampleLogStream(Stream &_wrapped) : wrapped(_wrapped), prefixWritten(false) {}
+    ExampleLogPrint(Print &_wrapped) : wrapped(_wrapped), prefixWritten(false) {}
 
-    // virtual functions from Stream
-    int available() {
-        return wrapped.available();
-    }
-    int read() {
-        return wrapped.read();
-    }
-    int peek() {
-        return wrapped.peek();
-    }
-
-    // virtual function from Print (from Stream)
+    // virtual function from Print
     size_t write(uint8_t c) {
         size_t s = 0;
         if (! prefixWritten) {

--- a/examples/ZeroRegsExampleLogger/ExampleLogStream.h
+++ b/examples/ZeroRegsExampleLogger/ExampleLogStream.h
@@ -1,0 +1,75 @@
+#ifndef EXAMPLE_LOG_STREAM_H
+#define EXAMPLE_LOG_STREAM_H
+
+#include <Stream.h>
+
+
+class ExampleLogStream : public Stream {
+    Stream &wrapped;
+    bool prefixWritten;
+
+    // copied(simplified) from platformio packages/framework-arduinosam/cores/samd/Print.cpp
+    size_t writeNumber(unsigned long n) {
+        char buf[8 * sizeof(long) + 1];
+        char *str = &buf[sizeof(buf) - 1];
+        *str = '\0';
+        do {
+            char c = n % 10;
+            n /= 10;
+            *--str = c + '0';
+        } while(n);
+        return wrapped.write(str);
+    }
+
+    size_t writePrefix() {
+        size_t s = 0;
+        s += wrapped.write('[');
+        s += writeNumber(millis());
+        s += wrapped.write(']');
+        s += wrapped.write(" level=info msg=\"");
+        return s;
+    }
+
+    size_t writeSuffix() {
+        return wrapped.write('\"');
+    }
+
+public:
+    ExampleLogStream(Stream &_wrapped) : wrapped(_wrapped), prefixWritten(false) {}
+
+    // virtual functions from Stream
+    int available() {
+        return wrapped.available();
+    }
+    int read() {
+        return wrapped.read();
+    }
+    int peek() {
+        return wrapped.peek();
+    }
+
+    // virtual function from Print (from Stream)
+    size_t write(uint8_t c) {
+        size_t s = 0;
+        if (! prefixWritten) {
+            s += writePrefix();
+            prefixWritten = true;
+        }
+        if (c == '"') {
+            // escape the quote we're about to write
+            s += wrapped.write('\\');
+        }
+        if (c == '\r') {
+            s += writeSuffix();
+        }
+        if (c == '\n') {
+            // this will cause us to reshow the prefix on the next line
+            prefixWritten = false;
+        }
+        s += wrapped.write(c);
+        return s;
+    }
+};
+
+
+#endif /*EXAMPLE_LOG_STREAM_H*/

--- a/examples/ZeroRegsExampleLogger/ZeroRegsExampleLogger.ino
+++ b/examples/ZeroRegsExampleLogger/ZeroRegsExampleLogger.ino
@@ -1,7 +1,7 @@
 #include <ZeroRegs.h>
-#include "ExampleLogStream.h"
+#include "ExampleLogPrint.h"
 
-ExampleLogStream logger(Serial);
+ExampleLogPrint logger(Serial);
 bool serialShown = false;
 
 void setup() {

--- a/examples/ZeroRegsExampleLogger/ZeroRegsExampleLogger.ino
+++ b/examples/ZeroRegsExampleLogger/ZeroRegsExampleLogger.ino
@@ -1,0 +1,21 @@
+#include <ZeroRegs.h>
+#include "ExampleLogStream.h"
+
+ExampleLogStream logger(Serial);
+bool serialShown = false;
+
+void setup() {
+    Serial.begin(9600);
+}
+
+void loop() {
+    if (Serial) {
+        if (! serialShown) {
+            ZeroRegOptions opts = { logger, false };
+            printZeroRegs(opts);
+            serialShown = true;
+        }
+    } else {
+        serialShown = false;
+    }
+}


### PR DESCRIPTION
In this example we create a custom `Print &` which wraps the output lines.

This hopefully addresses feature request #6.